### PR TITLE
Persist extracted docling images to disk

### DIFF
--- a/document_processor/docling_processor.py
+++ b/document_processor/docling_processor.py
@@ -23,6 +23,7 @@ from pathlib import Path
 import tempfile
 from datetime import datetime
 import traceback
+import imghdr
 
 # ✅ ИСПРАВЛЕНО: Правильные импорты Docling v2.0+
 from docling.document_converter import DocumentConverter, PdfFormatOption
@@ -140,9 +141,118 @@ class DoclingProcessor:
         
         # ✅ ИСПРАВЛЕНО: Инициализируем базовый конвертер БЕЗ OCR
         self._initialize_base_converter()
-        
+
         logger.info("DoclingProcessor initialized with conditional OCR loading")
-    
+
+    def _resolve_image_bytes(self, payload: Any) -> Optional[bytes]:
+        """Attempt to extract raw bytes from a payload returned by Docling images."""
+
+        if payload is None:
+            return None
+
+        try:
+            if isinstance(payload, (bytes, bytearray, memoryview)):
+                return bytes(payload)
+
+            # io.BytesIO and similar expose getbuffer / getvalue / read methods
+            if hasattr(payload, "getbuffer"):
+                try:
+                    buffer = payload.getbuffer()
+                    return bytes(buffer)
+                except Exception:
+                    pass
+
+            if hasattr(payload, "to_bytes") and callable(payload.to_bytes):
+                try:
+                    return payload.to_bytes()
+                except Exception:
+                    pass
+
+            if hasattr(payload, "tobytes") and callable(payload.tobytes):
+                try:
+                    return payload.tobytes()
+                except Exception:
+                    pass
+
+            if hasattr(payload, "getvalue") and callable(payload.getvalue):
+                try:
+                    value = payload.getvalue()
+                    if isinstance(value, (bytes, bytearray, memoryview)):
+                        return bytes(value)
+                except Exception:
+                    pass
+
+            if hasattr(payload, "read") and callable(payload.read):
+                try:
+                    data = None
+                    if hasattr(payload, "seek") and callable(payload.seek):
+                        current_position = None
+                        if hasattr(payload, "tell") and callable(payload.tell):
+                            try:
+                                current_position = payload.tell()
+                            except Exception:
+                                current_position = None
+                        try:
+                            payload.seek(0)
+                        except Exception:
+                            current_position = None
+                        data = payload.read()
+                        if current_position is not None:
+                            try:
+                                payload.seek(current_position)
+                            except Exception:
+                                pass
+                    else:
+                        data = payload.read()
+
+                    if isinstance(data, str):
+                        data = data.encode()
+
+                    if isinstance(data, (bytes, bytearray, memoryview)):
+                        return bytes(data)
+                except Exception:
+                    pass
+
+        except Exception:
+            logger.debug("Failed to resolve image payload into bytes", exc_info=True)
+
+        return None
+
+    def _detect_image_extension(self, image_obj: Any, image_bytes: Optional[bytes]) -> str:
+        """Determine the most appropriate extension for an exported image."""
+
+        format_hint: Optional[str] = None
+
+        for attr in ("format", "mime_type", "media_type"):
+            value = getattr(image_obj, attr, None)
+            if value:
+                format_hint = str(value).strip().lower()
+                break
+
+        extension = None
+        if format_hint:
+            if "/" in format_hint:
+                format_hint = format_hint.split("/")[-1]
+            format_hint = format_hint.lstrip(".")
+
+            if format_hint == "jpeg":
+                extension = "jpg"
+            elif format_hint == "tiff":
+                extension = "tif"
+            elif format_hint:
+                extension = format_hint
+
+        if not extension and image_bytes:
+            detected = imghdr.what(None, h=image_bytes)
+            if detected == "jpeg":
+                extension = "jpg"
+            elif detected == "tiff":
+                extension = "tif"
+            elif detected:
+                extension = detected
+
+        return extension or "bin"
+
     def _initialize_base_converter(self):
         """✅ ИСПРАВЛЕНО: Инициализация базового конвертера без OCR"""
         try:
@@ -422,6 +532,9 @@ class DoclingProcessor:
             
             # Извлечение изображений
             images = []
+            output_dir_path = Path(output_dir)
+            output_dir_path.mkdir(parents=True, exist_ok=True)
+
             if hasattr(docling_document, 'images'):
                 for i, image in enumerate(docling_document.images):
                     image_data = {
@@ -430,13 +543,66 @@ class DoclingProcessor:
                         "bbox": getattr(image, 'bbox', None),
                         "format": getattr(image, 'format', 'unknown')
                     }
-                    
-                    # Сохранение изображения
-                    if hasattr(image, 'data'):
-                        image_file = Path(output_dir) / f"image_{i}.png"
-                        # Здесь должна быть логика сохранения изображения
-                        image_data["file_path"] = str(image_file)
-                    
+
+                    payload_candidates: List[Any] = []
+
+                    for attr_name in ("data", "content", "buffer", "bytes", "raw"):
+                        if not hasattr(image, attr_name):
+                            continue
+                        candidate = getattr(image, attr_name)
+                        if callable(candidate):
+                            try:
+                                candidate = candidate()
+                            except Exception:
+                                continue
+                        payload_candidates.append(candidate)
+
+                    for method_name in ("get_data", "getbuffer", "to_bytes", "tobytes"):
+                        method = getattr(image, method_name, None)
+                        if callable(method):
+                            try:
+                                payload_candidates.append(method())
+                            except Exception:
+                                continue
+
+                    saved = False
+                    for payload in payload_candidates:
+                        image_bytes = self._resolve_image_bytes(payload)
+                        if not image_bytes:
+                            continue
+
+                        extension = self._detect_image_extension(image, image_bytes)
+                        image_file = output_dir_path / f"image_{i}.{extension}"
+
+                        try:
+                            with open(image_file, "wb") as f:
+                                f.write(image_bytes)
+                            image_data["file_path"] = str(image_file)
+                            image_data["size_bytes"] = len(image_bytes)
+                            saved = True
+                            break
+                        except Exception as write_error:
+                            logger.warning(
+                                "Failed to write image %s to %s: %s",
+                                i,
+                                image_file,
+                                write_error,
+                            )
+                            if image_file.exists():
+                                try:
+                                    image_file.unlink()
+                                except Exception:
+                                    logger.debug(
+                                        "Failed to clean up incomplete image file %s",
+                                        image_file,
+                                        exc_info=True,
+                                    )
+
+                    if not saved:
+                        logger.warning(
+                            "Unable to persist image %s from %s", i, original_file_path
+                        )
+
                     images.append(image_data)
             
             # ✅ НОВОЕ: Продвинутое chunking если доступно


### PR DESCRIPTION
## Summary
- add helpers to resolve docling image payloads into raw bytes and determine file extensions
- write extracted images to the output directory only when persistence succeeds and emit warnings otherwise

## Testing
- python - <<'PY' ... PY

------
https://chatgpt.com/codex/tasks/task_e_68e414becffc8331a3005f460790e20d