### PR TITLE
Initialize chunker during DoclingProcessor construction

### DIFF
--- a/document_processor/docling_processor.py
+++ b/document_processor/docling_processor.py
@@ -142,6 +142,25 @@ class DoclingProcessor:
         # ✅ ИСПРАВЛЕНО: Инициализируем базовый конвертер БЕЗ OCR
         self._initialize_base_converter()
 
+        # ✅ ИНИЦИАЛИЗИРУЕМ CHUNKER, ЕСЛИ ДОСТУПНЫ НЕОБХОДИМЫЕ ЗАВИСИМОСТИ
+        try:
+            self._initialize_chunker()
+        except Exception as chunker_error:
+            logger.warning(
+                "Chunker initialization failed during startup",
+                error=str(chunker_error),
+            )
+
+        if self.chunker is not None:
+            logger.info("Chunker status: enabled")
+        else:
+            status_msg = (
+                "Chunker status: skipped (transformers not available)"
+                if not HF_TRANSFORMERS_AVAILABLE
+                else "Chunker status: disabled"
+            )
+            logger.info(status_msg)
+
         logger.info("DoclingProcessor initialized with conditional OCR loading")
 
     def _resolve_image_bytes(self, payload: Any) -> Optional[bytes]:


### PR DESCRIPTION
## Summary
- initialize the chunker during `DoclingProcessor` construction while tolerating missing transformers
- add concise logging that reports the chunker status to aid troubleshooting

## Testing
- python3 -m document_processor.local_converter --help *(fails: ModuleNotFoundError: No module named 'docling')*

------
https://chatgpt.com/codex/tasks/task_e_68e41a90c0cc8331bcbacd3d4af22473